### PR TITLE
Refactory fitter class to handle list of signal and bkg pdfs

### DIFF
--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -55,10 +55,12 @@ class DataHandler:
                             nbins = len(hist_array[1]) - 1
                             self._limits_[0] = hist_array[1][0]
                             self._limits_[1] = hist_array[1][-1]
+                            idx_min = 0
+                            idx_max = len(hist_array[1])-1
                         else:
                             idx_min = np.argmin(np.abs(hist_array[1]-self._limits_[0]))
                             idx_max = np.argmin(np.abs(hist_array[1]-self._limits_[1]))
-                            nbins = len(hist_array[1][idx_min:idx_max+1])
+                            nbins = len(hist_array[1][idx_min:idx_max])
                             self._limits_[0] = hist_array[1][idx_min]
                             self._limits_[1] = hist_array[1][idx_max]
                         binning = zfit.binned.RegularBinning(
@@ -69,8 +71,8 @@ class DataHandler:
                         )
                         self._obs_ = zfit.Space("xaxis", binning=binning)
                         self._binned_data_ = zfit.data.BinnedData.from_tensor(
-                            self._obs_, hist_array[0][idx_min:idx_max+1],
-                            np.sqrt(hist_array[0][idx_min:idx_max+1]))
+                            self._obs_, hist_array[0][idx_min:idx_max],
+                            np.sqrt(hist_array[0][idx_min:idx_max]))
                         self._isbinned_ = True
                     elif 'treename' in kwargs:
                         input_df = uproot.open(data)[kwargs['treename']].arrays(library='pd')

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -432,7 +432,7 @@ class F2MassFitter:
         """
 
         if self._name_signal_pdf_[idx] not in ['gaussian', 'crystalball']:
-            # FIXME: add possibility to compute signal not based on nsigma
+            # TODO: add possibility to compute signal not based on nsigma
             Logger('Sigma not defined, I cannot compute the signal for this pdf', 'ERROR')
             return 0., 0.
 

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -459,7 +459,7 @@ class F2MassFitter:
                 frac_err = signal_err_fracs[idx]
             else:
                 frac = 1. - sum(signal_fracs)
-                frac_err = np.sqrt(sum([err**2 for err in signal_err_fracs]))
+                frac_err = np.sqrt(sum(list(err**2 for err in signal_err_fracs)))
 
         norm = self._data_handler_.get_norm()
         norm_err = norm * frac_err
@@ -501,7 +501,7 @@ class F2MassFitter:
         signal_fracs, _, signal_err_fracs, _ = self.__get_all_fracs()
 
         frac = 1. - len(signal_fracs)
-        frac_err = np.sqrt(sum([err**2 for err in signal_err_fracs]))
+        frac_err = np.sqrt(sum(list(err**2 for err in signal_err_fracs)))
 
         norm = self._data_handler_.get_norm()
         norm_err = norm * frac_err

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -78,7 +78,7 @@ class F2MassFitter:
                     mu=self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'],
                     sigma=self._sgn_pars_[ipdf][f'{self._name_}_sigma_signal{ipdf}']
                 )
-            elif self._name_signal_pdf_ == 'cauchy':
+            elif pdf_name == 'cauchy':
                 self._init_sgn_pars_[ipdf].setdefault("m", 1.865)
                 self._init_sgn_pars_[ipdf].setdefault("gamma", 0.010)
                 self._sgn_pars_[ipdf][f'{self._name_}_m_signal{ipdf}'] = zfit.Parameter(
@@ -90,7 +90,7 @@ class F2MassFitter:
                     m=self._sgn_pars_[ipdf][f'{self._name_}_m_signal{ipdf}'],
                     gamma=self._sgn_pars_[ipdf][f'{self._name_}_gamma_signal{ipdf}']
                 )
-            elif self._name_signal_pdf_ == 'crystalball':
+            elif pdf_name == 'crystalball':
                 self._init_sgn_pars_[ipdf].setdefault("mu", 1.865)
                 self._init_sgn_pars_[ipdf].setdefault("sigma", 0.010)
                 self._init_sgn_pars_[ipdf].setdefault("alpha", 0.5)

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -166,6 +166,7 @@ class F2MassFitter:
         """
         Helper function to perform a prefit to the sidebands
         """
+        # pylint: disable=fixme
         #TODO: implement me
         Logger('Prefit step to be implemented', 'WARNING')
 
@@ -209,6 +210,7 @@ class F2MassFitter:
             Logger('Data handler not specified', 'FATAL')
 
         self.__build_total_pdf()
+        # pylint: disable=fixme
         self.__prefit() #TODO: implement me
 
         if self._data_handler_.get_is_binned():
@@ -432,6 +434,7 @@ class F2MassFitter:
         """
 
         if self._name_signal_pdf_[idx] not in ['gaussian', 'crystalball']:
+            # pylint: disable=fixme
             # TODO: add possibility to compute signal not based on nsigma
             Logger('Sigma not defined, I cannot compute the signal for this pdf', 'ERROR')
             return 0., 0.

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -390,7 +390,7 @@ class F2MassFitter:
         return self._fit_result_.params[f'{self._name_}_sigma_signal{idx}']['value'], \
             self._fit_result_.params[f'{self._name_}_sigma_signal{idx}']['hesse']['error']
 
-    def get_parameter(self, idx=0, par):
+    def get_parameter(self, idx, par):
         """
         Get the width and its error
 

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -528,15 +528,15 @@ class F2MassFitter:
             The S/B error obtained from the fit
         """
 
-        signal = self.get_signal(nsigma, idx)
-        bkg = self.get_background(nsigma, idx)
+        signal = self.get_signal(idx, nsigma)
+        bkg = self.get_background(idx, nsigma)
         signal_over_background = signal[0]/bkg[0]
         signal_over_background_err = np.sqrt(signal[1]**2/signal[0]**2 + bkg[1]**2/bkg[0]**2)
         signal_over_background_err *= signal_over_background
 
         return signal_over_background, signal_over_background_err
 
-    def get_significance(self, nsigma, idx=0):
+    def get_significance(self, idx=0, nsigma=3):
         """
         Get the significance and its error in mass +- nsigma * width
 
@@ -555,8 +555,8 @@ class F2MassFitter:
             The significance error obtained from the fit
         """
 
-        signal = self.get_signal(nsigma, idx)
-        bkg = self.get_background(nsigma, idx)
+        signal = self.get_signal(idx, nsigma)
+        bkg = self.get_background(idx, nsigma)
         significance = signal[0]/np.sqrt(signal[0]+bkg[0])
         sig_plus_bkg = signal[0] + bkg[0]
 

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -307,7 +307,6 @@ class F2MassFitter:
         # then draw signals
         base_sgn_cmap = plt.cm.get_cmap('viridis', len(signal_funcs) * 4)
         sgn_cmap = ListedColormap(base_sgn_cmap(np.linspace(0.4, 0.65, len(signal_funcs))))
-        print(sgn_cmap, base_sgn_cmap)
         for isgn, (frac, signal_func) in enumerate(zip(signal_funcs, signal_fracs)):
             plt.plot(x_plot, signal_func * norm * frac, color=sgn_cmap(isgn))
             plt.fill_between(x_plot, signal_func * norm * frac, color=sgn_cmap(isgn),

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -301,7 +301,7 @@ class F2MassFitter:
                          ls="--", label=f'background {ibkg}')
             else:
                 plt.plot(x_plot, bkg_func * norm * (1-sum(bkg_fracs)-sum(signal_fracs)),
-                         color='firebrick', ls="--", label='background')
+                         color='firebrick', ls="--", label=f'background {ibkg}')
         # then draw signals
         base_sgn_cmap = plt.cm.get_cmap('viridis', len(signal_funcs) * 4)
         sgn_cmap = ListedColormap(base_sgn_cmap(np.linspace(0.4, 0.65, len(signal_funcs))))
@@ -371,7 +371,7 @@ class F2MassFitter:
         return self._fit_result_.params[f'{self._name_}_{mass_name}_signal{idx}']['value'], \
             self._fit_result_.params[f'{self._name_}_{mass_name}_signal{idx}']['hesse']['error']
 
-    def get_sigma(self, idx):
+    def get_sigma(self, idx=0):
         """
         Get the sigma and its error
 
@@ -390,16 +390,16 @@ class F2MassFitter:
         return self._fit_result_.params[f'{self._name_}_sigma_signal{idx}']['value'], \
             self._fit_result_.params[f'{self._name_}_sigma_signal{idx}']['hesse']['error']
 
-    def get_parameter(self, par, idx=0):
+    def get_parameter(self, idx=0, par):
         """
         Get the width and its error
 
         Parameters
         -------------------------------------------------
-        par: str
-            parameter to return
         idx: int
             Index of the sigma to be returned (default: 0)
+        par: str
+            parameter to return
 
         Returns
         -------------------------------------------------
@@ -412,16 +412,16 @@ class F2MassFitter:
         return self._fit_result_.params[f'{self._name_}_{par}_signal{idx}']['value'], \
             self._fit_result_.params[f'{self._name_}_{par}_signal{idx}']['hesse']['error']
 
-    def get_signal(self, nsigma=3, idx=0):
+    def get_signal(self, idx=0, nsigma=3):
         """
         Get the signal and its error in mass +- nsigma * width
 
         Parameters
         -------------------------------------------------
-        nsigma: float
-            nsigma window for signal computation
         idx: int
             Index of the signal to be returned
+        nsigma: float
+            nsigma window for signal computation
 
         Returns
         -------------------------------------------------
@@ -467,16 +467,16 @@ class F2MassFitter:
 
         return float(signal * norm), float(signal * norm_err)
 
-    def get_background(self, nsigma=3, idx=0):
+    def get_background(self, idx=0, nsigma=3):
         """
         Get the background and its error in mass +- nsigma * width
 
         Parameters
         -------------------------------------------------
-        nsigma: float
-            nsigma window for background computation
         idx: int
             Index of the signal to be used to compute nsigma window
+        nsigma: float
+            nsigma window for background computation
 
         Returns
         -------------------------------------------------
@@ -509,16 +509,16 @@ class F2MassFitter:
 
         return float(background * norm), float(background * norm_err)
 
-    def get_signal_over_background(self, nsigma=3, idx=0):
+    def get_signal_over_background(self, idx=0, nsigma=3):
         """
         Get the S/B ratio and its error in mass +- nsigma * width
 
         Parameters
         -------------------------------------------------
-        nsigma: float
-            nsigma window for background computation
         idx: int
             Index of the signal to be used to compute nsigma window
+        nsigma: float
+            nsigma window for background computation
 
         Returns
         -------------------------------------------------
@@ -542,10 +542,10 @@ class F2MassFitter:
 
         Parameters
         -------------------------------------------------
-        nsigma: float
-            nsigma window for background computation
         idx: int
             Index of the signal to be used to compute nsigma window
+        nsigma: float
+            nsigma window for background computation
 
         Returns
         -------------------------------------------------

--- a/tests/test_massfitter_binned.py
+++ b/tests/test_massfitter_binned.py
@@ -10,7 +10,7 @@ import matplotlib
 from flarefly.data_handler import DataHandler
 from flarefly.fitter import F2MassFitter
 
-INFILE = os.path.join(os.getcwd(), "tests/histos.root")
+INFILE = os.path.join(os.getcwd(), "histos.root")
 DATABINNED = DataHandler(INFILE, var_name=r'$M_\mathrm{K\pi\pi}$ (GeV/$c^{2}$)',
                          histoname='hMass_80_120', limits=[1.75, 2.06])
 
@@ -26,6 +26,8 @@ FIG = FITTERBINNED.plot_mass_fit('ATLAS')
 
 RAWYHIST = uproot.open(INFILE)["hRawYields"].to_numpy()
 RAWYIN = RAWYHIST[0][4]
+
+matplotlib.pyplot.show()
 
 def test_fitter():
     """

--- a/tests/test_massfitter_binned.py
+++ b/tests/test_massfitter_binned.py
@@ -10,7 +10,7 @@ import matplotlib
 from flarefly.data_handler import DataHandler
 from flarefly.fitter import F2MassFitter
 
-INFILE = os.path.join(os.getcwd(), "histos.root")
+INFILE = os.path.join(os.getcwd(), "tests/histos.root")
 DATABINNED = DataHandler(INFILE, var_name=r'$M_\mathrm{K\pi\pi}$ (GeV/$c^{2}$)',
                          histoname='hMass_80_120', limits=[1.75, 2.06])
 

--- a/tests/test_massfitter_binned.py
+++ b/tests/test_massfitter_binned.py
@@ -10,13 +10,17 @@ import matplotlib
 from flarefly.data_handler import DataHandler
 from flarefly.fitter import F2MassFitter
 
-INFILE = os.path.join(os.getcwd(), "tests/histos.root")
+INFILE = os.path.join(os.getcwd(), "histos.root")
 DATABINNED = DataHandler(INFILE, var_name=r'$M_\mathrm{K\pi\pi}$ (GeV/$c^{2}$)',
                          histoname='hMass_80_120', limits=[1.75, 2.06])
 
-FITTERBINNED = F2MassFitter(DATABINNED, name_signal_pdf='gaussian', name_background_pdf='expo')
-FITTERBINNED.set_particle_mass(1.87)
-FITTERBINNED.set_secpeak("gaussian", 2.01, 0.01)
+FITTERBINNED = F2MassFitter(DATABINNED,
+                            name_signal_pdf=['gaussian', 'gaussian'],
+                            name_background_pdf=['expo'])
+FITTERBINNED.set_particle_mass(0, 1.87)
+FITTERBINNED.set_particle_mass(1, 2.01)
+FITTERBINNED.set_signal_initpar(0, "sigma", 0.010)
+FITTERBINNED.set_signal_initpar(1, "sigma", 0.015)
 FITRES = FITTERBINNED.mass_zfit()
 FIG = FITTERBINNED.plot_mass_fit('ATLAS')
 

--- a/tests/test_massfitter_unbinned.py
+++ b/tests/test_massfitter_unbinned.py
@@ -14,9 +14,10 @@ DATABKG = np.random.uniform(LIMITS[0], LIMITS[1], size=10000)
 DATA = DataHandler(np.concatenate((DATASGN, DATABKG), axis=0),
                    var_name=r'$M$ (GeV/$c^{2}$)', limits=LIMITS)
 
-FITTER = F2MassFitter(DATA, name_signal_pdf='gaussian', name_background_pdf='expo')
+FITTER = F2MassFitter(DATA, name_signal_pdf=['gaussian'],
+                      name_background_pdf=['expo'])
 FITRES = FITTER.mass_zfit()
-FIG = FITTER.plot_mass_fit()
+FIG = FITTER.plot_mass_fit(figsize=(10, 10))
 
 def test_fitter():
     """


### PR DESCRIPTION
- This PR modifies the way the fitter is initialised: now instead of a single pdf for the signal and one for the background, a list of pdfs is provided for both. This also removes the methods related to the "second peak", since a second peak can be just added in the list of signal pdfs.
- In addition this PR adds the 'cauchy' function in the pdfs available for the signals (more still to be added)
- Fixes indices in loaded binned histograms in data handler