### PR TITLE
Update zfit version

### DIFF
--- a/flarefly/custom_pdfs.py
+++ b/flarefly/custom_pdfs.py
@@ -8,7 +8,7 @@ from zfit import z
 from scipy import special
 
 # pylint: disable=too-many-ancestors
-
+# pylint: disable=arguments-differ
 
 class DoubleGauss(zfit.pdf.ZPDF):
     """

--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -260,7 +260,7 @@ class DataHandler:
             The observation space for binned data converted to unbinned data
         """
         limits = self.get_limits()
-        obs = zfit.Space("xaxis_unbinned", lower=limits[0], upper=limits[1])
+        obs = zfit.Space("xaxis", lower=limits[0], upper=limits[1])
 
         return obs
 

--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -97,7 +97,7 @@ class DataHandler:
                         if limits is None:
                             self._limits_[0] = min(input_df[self._var_name_])
                             self._limits_[1] = max(input_df[self._var_name_])
-                        self._obs_ = zfit.Space(self._var_name_, limits=(self._limits_[0], self._limits_[1]))
+                        self._obs_ = zfit.Space(self._var_name_, lower=self._limits_[0], upper=self._limits_[1])
                         self._data_ = zfit.data.Data.from_pandas(obs=self._obs_, df=input_df)
                     else:
                         Logger('"histoname" not specified. Please specify the '
@@ -108,7 +108,7 @@ class DataHandler:
                     if limits is None:
                         self._limits_[0] = min(input_df[self._var_name_])
                         self._limits_[1] = max(input_df[self._var_name_])
-                    self._obs_ = zfit.Space(self._var_name_, limits=(self._limits_[0], self._limits_[1]))
+                    self._obs_ = zfit.Space(self._var_name_, lower=self._limits_[0], upper=self._limits_[1])
                     self._data_ = zfit.data.Data.from_pandas(obs=self._obs_, df=input_df)
                 else:
                     Logger('Data format not supported yet. Please use .root or .parquet', 'FATAL')
@@ -118,7 +118,7 @@ class DataHandler:
                 if limits is None:
                     self._limits_[0] = min(data)
                     self._limits_[1] = max(data)
-                self._obs_ = zfit.Space(self._var_name_, limits=(self._limits_[0], self._limits_[1]))
+                self._obs_ = zfit.Space(self._var_name_, lower=self._limits_[0], upper=self._limits_[1])
                 self._data_ = zfit.data.Data.from_numpy(obs=self._obs_, array=data)
 
             elif isinstance(data, pd.DataFrame):
@@ -126,7 +126,7 @@ class DataHandler:
                 if limits is None:
                     self._limits_[0] = min(data[self._var_name_])
                     self._limits_[1] = max(data[self._var_name_])
-                self._obs_ = zfit.Space(self._var_name_, limits=(self._limits_[0], self._limits_[1]))
+                self._obs_ = zfit.Space(self._var_name_, lower=self._limits_[0], upper=self._limits_[1])
                 self._data_ = zfit.data.Data.from_pandas(obs=self._obs_, df=data)
 
             elif isinstance(data, uproot.behaviors.TH1.Histogram):
@@ -240,13 +240,27 @@ class DataHandler:
 
         Returns
         -------------------------------------------------
-        binned_data: zfit.core.space.Space
+        binned_obs: zfit.core.space.Space
             The observation space for unbinned data converted to binned data
         """
         bins = self.get_nbins()
         limits = self.get_limits()
         binning = zfit.binned.RegularBinning(bins, limits[0], limits[1], name=self._var_name_)
         obs = zfit.Space(self._var_name_, binning=binning)
+
+        return obs
+
+    def get_unbinned_obs_from_binned_data(self):
+        """
+        Get the unbinned obs from binned obs
+
+        Returns
+        -------------------------------------------------
+        unbinned_obs: zfit.core.space.Space
+            The observation space for binned data converted to unbinned data
+        """
+        limits = self.get_limits()
+        obs = zfit.Space("xaxis_unbinned", lower=limits[0], upper=limits[1])
 
         return obs
 

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -667,7 +667,10 @@ class F2MassFitter:
         Helper function to compose the total pdf
         """
 
-        obs = self._data_handler_.get_obs()
+        if self._data_handler_.get_is_binned(): # we need unbinned pdfs to sum them
+            obs = self._data_handler_.get_unbinned_obs_from_binned_data()
+        else:
+            obs = self._data_handler_.get_obs()
 
         # order of the pdfs is signal, background
 
@@ -716,7 +719,8 @@ class F2MassFitter:
                     self._limits_bkg_pars_[ipdf]['frac'][1],
                     floating=not self._fix_bkg_pars_[ipdf]['frac'])
 
-        self._total_pdf_ = zfit.pdf.SumPDF(self._signal_pdf_+self._refl_pdf_+self._background_pdf_, self._fracs_)
+        self._total_pdf_ = zfit.pdf.SumPDF(self._signal_pdf_+self._refl_pdf_+self._background_pdf_,
+                                           self._fracs_)
 
     def __build_total_pdf_binned(self):
         """
@@ -886,7 +890,7 @@ class F2MassFitter:
             else:
                 loss = zfit.loss.BinnedNLL(self._total_pdf_binned_, self._data_handler_.get_binned_data())
         else:
-            loss = zfit.loss.UnbinnedNLL(model=self._total_pdf_, data=self._data_handler_.get_data())
+            loss = zfit.loss.UnbinnedNLL(model=self._total_pdf_binned_, data=self._data_handler_.get_data())
 
         self._fit_result_ = self._minimizer_.minimize(loss=loss)
         Logger(self._fit_result_, 'RESULT')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 psutil
 dutil
-numpy>=1.20
-pandas>=1.1.5
-uproot>=4.3.4
-zfit==0.18.2
-mplhep>=0.3.25
-matplotlib>=3.1.3
+numpy<1.25
+pandas>=2.2.0
+uproot>=5.0
+zfit>=0.20.2
+mplhep>=0.3.46
+matplotlib>=3.8
 particle>=0.20.1
 scipy>=1.7.3

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,8 @@ SETUP = Setup(
     # installed. For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "psutil", "dutil", "prophet>=1.0.1", "numpy>=1.20", "pandas>=1.1.5", "uproot>=4.3.4",
-        "ipython>=7.16.1", "jedi==0.17.2", "zfit==0.18.2", "mplhep>=0.3.25", "matplotlib>=3.1.3",
+        "psutil", "dutil", "prophet>=1.0.1", "numpy<1.25", "pandas>=2.2", "uproot>=5.0",
+        "ipython>=7.16.1", "jedi>=0.17.2", "zfit>=0.20.2", "mplhep>=0.3.46", "matplotlib>=3.8",
         "particle>=0.20.1", "scipy>=1.7.3"
     ],
     python_requires=">=3.8",

--- a/tests/test_massfitter_binned.py
+++ b/tests/test_massfitter_binned.py
@@ -15,7 +15,7 @@ FITTERBINNEDDPLUS, FITTERBINNEDDSTAR, FITTERBINNEDD0, FITRES, FIG, RAWYHIST, RAW
 SGNPDFSDPLUS = ["gaussian", "crystalball", "doublegaus", "doublecb"]
 BKGPDFSDPLUS = ["expo", "chebpol1"]
 SGNPDFSDSTAR = ["gaussian", "voigtian"]
-BKGPDFSDSTAR = ["expopow", "powlaw"]
+BKGPDFSDSTAR = ["expopow", "powlaw", "expopowext"]
 SGNPDFSD0 = ["gaussian"]
 BKGPDFSD0 = ["expo"]
 


### PR DESCRIPTION
Due to a change of behaviour in `zfit`, now PDFs are defined as binned if the observable space is binned. However, the `SumPDF` does not work with binned PDFs, hence I had to add the possibility to define an unbinned observable space from the binned one in order to be able to define unbinned PDFs before summing them.