### PR TITLE
Add signal pdfs from new zfit version and dump version

### DIFF
--- a/flarefly/custom_pdfs.py
+++ b/flarefly/custom_pdfs.py
@@ -4,8 +4,6 @@ Module containing custom pdfs
 
 import zfit
 import tensorflow as tf
-from zfit import z
-from scipy import special
 
 # pylint: disable=too-many-ancestors
 # pylint: disable=arguments-differ

--- a/flarefly/custom_pdfs.py
+++ b/flarefly/custom_pdfs.py
@@ -132,38 +132,3 @@ class ExpoPowExt(zfit.pdf.ZPDF):
         c2 = self.params['c2']
         c3 = self.params['c3']
         return tf.pow(x - mass, power) * tf.exp(c1 * (x - mass) + c2 * (x - mass)**2 + c3 * (x - mass)**3)
-
-class Voigtian(zfit.pdf.ZPDF):
-    """
-    Voigtian PDF defined starting from the scipy.special definition
-    See https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.voigt_profile.html
-    for more details
-
-    Parameters:
-
-        - mu: mass parameter
-
-        - sigma: sigma of the gaussian
-
-        - gamma: gamma of the cauchy
-    """
-
-    # override the name of the parameters
-    _PARAMS = ['mu', 'sigma', 'gamma']
-
-    def _unnormalized_pdf(self, x):
-        """
-        PDF 'unnormalized'.
-        See https://zfit.github.io/zfit/_modules/zfit/core/basepdf.html#BasePDF.unnormalized_pdf
-        for more details
-        """
-
-        x = zfit.z.unstack_x(x)
-        mass = self.params['mu']
-        gamma = self.params['gamma']
-        sigma = self.params['sigma']
-
-        # pylint: disable=no-member
-        voigt_tf = z.py_function(func=special.voigt_profile, inp=[x - mass, sigma, gamma], Tout=tf.float64)
-
-        return voigt_tf

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -41,9 +41,17 @@ class F2MassFitter:
 
             - 'doublegaus'
 
+            - 'gausexptail'
+
+            - 'genergausexptail'
+
+            - 'bifurgaus'
+
             - 'crystalball'
 
             - 'doublecb'
+
+            - 'genercrystalball'
 
             - 'cauchy'
 
@@ -376,19 +384,19 @@ class F2MassFitter:
                     gamma=self._sgn_pars_[ipdf][f'{self._name_}_gamma_signal{ipdf}']
                 )
             elif pdf_name == 'voigtian':
-                self._init_sgn_pars_[ipdf].setdefault('mu', 1.865)
+                self._init_sgn_pars_[ipdf].setdefault('m', 1.865)
                 self._init_sgn_pars_[ipdf].setdefault('gamma', 0.010)
                 self._init_sgn_pars_[ipdf].setdefault('sigma', 0.010)
                 self._fix_sgn_pars_[ipdf].setdefault('mu', False)
                 self._fix_sgn_pars_[ipdf].setdefault('gamma', False)
                 self._fix_sgn_pars_[ipdf].setdefault('sigma', False)
-                self._limits_sgn_pars_[ipdf].setdefault('mu', [0, 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('m', [0, 1.e6])
                 self._limits_sgn_pars_[ipdf].setdefault('gamma', [0., 1.e6])
                 self._limits_sgn_pars_[ipdf].setdefault('sigma', [0., 1.e6])
-                self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'] = zfit.Parameter(
-                    f'{self._name_}_mu_signal{ipdf}', self._init_sgn_pars_[ipdf]['mu'],
-                    self._limits_sgn_pars_[ipdf]['mu'][0], self._limits_sgn_pars_[ipdf]['mu'][1],
-                    floating=not self._fix_sgn_pars_[ipdf]['mu'])
+                self._sgn_pars_[ipdf][f'{self._name_}_m_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_m_signal{ipdf}', self._init_sgn_pars_[ipdf]['m'],
+                    self._limits_sgn_pars_[ipdf]['m'][0], self._limits_sgn_pars_[ipdf]['m'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['m'])
                 self._sgn_pars_[ipdf][f'{self._name_}_gamma_signal{ipdf}'] = zfit.Parameter(
                     f'{self._name_}_gamma_signal{ipdf}', self._init_sgn_pars_[ipdf]['gamma'],
                     self._limits_sgn_pars_[ipdf]['gamma'][0], self._limits_sgn_pars_[ipdf]['gamma'][1],
@@ -397,11 +405,171 @@ class F2MassFitter:
                     f'{self._name_}_sigma_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigma'],
                     self._limits_sgn_pars_[ipdf]['sigma'][0], self._limits_sgn_pars_[ipdf]['sigma'][1],
                     floating=not self._fix_sgn_pars_[ipdf]['sigma'])
-                self._signal_pdf_[ipdf] = cpdf.Voigtian(
+                self._signal_pdf_[ipdf] = zfit.pdf.Voigt(
+                    obs=obs,
+                    m=self._sgn_pars_[ipdf][f'{self._name_}_m_signal{ipdf}'],
+                    sigma=self._sgn_pars_[ipdf][f'{self._name_}_sigma_signal{ipdf}'],
+                    gamma=self._sgn_pars_[ipdf][f'{self._name_}_gamma_signal{ipdf}']
+                )
+            elif pdf_name == 'gausexptail':
+                self._init_sgn_pars_[ipdf].setdefault('mu', 1.865)
+                self._init_sgn_pars_[ipdf].setdefault('alpha', 1.e6)
+                self._init_sgn_pars_[ipdf].setdefault('sigma', 0.010)
+                self._fix_sgn_pars_[ipdf].setdefault('mu', False)
+                self._fix_sgn_pars_[ipdf].setdefault('alpha', False)
+                self._fix_sgn_pars_[ipdf].setdefault('sigma', False)
+                self._limits_sgn_pars_[ipdf].setdefault('mu', [0, 1.e10])
+                self._limits_sgn_pars_[ipdf].setdefault('alpha', [-1.e10, 1.e10])
+                self._limits_sgn_pars_[ipdf].setdefault('sigma', [0., 1.e6])
+                self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_mu_signal{ipdf}', self._init_sgn_pars_[ipdf]['mu'],
+                    self._limits_sgn_pars_[ipdf]['mu'][0], self._limits_sgn_pars_[ipdf]['mu'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['mu'])
+                self._sgn_pars_[ipdf][f'{self._name_}_alpha_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_alpha_signal{ipdf}', self._init_sgn_pars_[ipdf]['alpha'],
+                    self._limits_sgn_pars_[ipdf]['alpha'][0], self._limits_sgn_pars_[ipdf]['alpha'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['alpha'])
+                self._sgn_pars_[ipdf][f'{self._name_}_sigma_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_sigma_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigma'],
+                    self._limits_sgn_pars_[ipdf]['sigma'][0], self._limits_sgn_pars_[ipdf]['sigma'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['sigma'])
+                self._signal_pdf_[ipdf] = zfit.pdf.GaussExpTail(
                     obs=obs,
                     mu=self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'],
                     sigma=self._sgn_pars_[ipdf][f'{self._name_}_sigma_signal{ipdf}'],
-                    gamma=self._sgn_pars_[ipdf][f'{self._name_}_gamma_signal{ipdf}']
+                    alpha=self._sgn_pars_[ipdf][f'{self._name_}_alpha_signal{ipdf}']
+                )
+            elif pdf_name == 'genergausexptail':
+                self._init_sgn_pars_[ipdf].setdefault('mu', 1.865)
+                self._init_sgn_pars_[ipdf].setdefault('alphar', 1.e6)
+                self._init_sgn_pars_[ipdf].setdefault('alphal', 1.e6)
+                self._init_sgn_pars_[ipdf].setdefault('sigmal', 0.010)
+                self._init_sgn_pars_[ipdf].setdefault('sigmar', 0.010)
+                self._fix_sgn_pars_[ipdf].setdefault('mu', False)
+                self._fix_sgn_pars_[ipdf].setdefault('alphar', False)
+                self._fix_sgn_pars_[ipdf].setdefault('alphal', False)
+                self._fix_sgn_pars_[ipdf].setdefault('sigmar', False)
+                self._fix_sgn_pars_[ipdf].setdefault('sigmal', False)
+                self._limits_sgn_pars_[ipdf].setdefault('mu', [0, 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('alphar', [-1.e10, 1.e10])
+                self._limits_sgn_pars_[ipdf].setdefault('alphal', [-1.e10, 1.e10])
+                self._limits_sgn_pars_[ipdf].setdefault('sigmar', [0., 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('sigmal', [0., 1.e6])
+                self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_mu_signal{ipdf}', self._init_sgn_pars_[ipdf]['mu'],
+                    self._limits_sgn_pars_[ipdf]['mu'][0], self._limits_sgn_pars_[ipdf]['mu'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['mu'])
+                self._sgn_pars_[ipdf][f'{self._name_}_alphar_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_alphar_signal{ipdf}', self._init_sgn_pars_[ipdf]['alphar'],
+                    self._limits_sgn_pars_[ipdf]['alphar'][0], self._limits_sgn_pars_[ipdf]['alphar'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['alphar'])
+                self._sgn_pars_[ipdf][f'{self._name_}_alphal_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_alphal_signal{ipdf}', self._init_sgn_pars_[ipdf]['alphal'],
+                    self._limits_sgn_pars_[ipdf]['alphal'][0], self._limits_sgn_pars_[ipdf]['alphal'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['alphal'])
+                self._sgn_pars_[ipdf][f'{self._name_}_sigmar_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_sigmar_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigmar'],
+                    self._limits_sgn_pars_[ipdf]['sigmar'][0], self._limits_sgn_pars_[ipdf]['sigmar'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['sigmar'])
+                self._sgn_pars_[ipdf][f'{self._name_}_sigmal_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_sigmal_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigmal'],
+                    self._limits_sgn_pars_[ipdf]['sigmal'][0], self._limits_sgn_pars_[ipdf]['sigmal'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['sigmal'])
+                self._signal_pdf_[ipdf] = zfit.pdf.GeneralizedGaussExpTail(
+                    obs=obs,
+                    mu=self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'],
+                    sigmar=self._sgn_pars_[ipdf][f'{self._name_}_sigmar_signal{ipdf}'],
+                    sigmal=self._sgn_pars_[ipdf][f'{self._name_}_sigmal_signal{ipdf}'],
+                    alphar=self._sgn_pars_[ipdf][f'{self._name_}_alphar_signal{ipdf}'],
+                    alphal=self._sgn_pars_[ipdf][f'{self._name_}_alphal_signal{ipdf}']
+                )
+            elif pdf_name == 'bifurgaus':
+                self._init_sgn_pars_[ipdf].setdefault('mu', 1.865)
+                self._init_sgn_pars_[ipdf].setdefault('sigmal', 0.010)
+                self._init_sgn_pars_[ipdf].setdefault('sigmar', 0.010)
+                self._fix_sgn_pars_[ipdf].setdefault('mu', False)
+                self._fix_sgn_pars_[ipdf].setdefault('sigmar', False)
+                self._fix_sgn_pars_[ipdf].setdefault('sigmal', False)
+                self._limits_sgn_pars_[ipdf].setdefault('mu', [0, 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('sigmar', [0., 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('sigmal', [0., 1.e6])
+                self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_mu_signal{ipdf}', self._init_sgn_pars_[ipdf]['mu'],
+                    self._limits_sgn_pars_[ipdf]['mu'][0], self._limits_sgn_pars_[ipdf]['mu'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['mu'])
+                self._sgn_pars_[ipdf][f'{self._name_}_sigmar_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_sigmar_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigmar'],
+                    self._limits_sgn_pars_[ipdf]['sigmar'][0], self._limits_sgn_pars_[ipdf]['sigmar'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['sigmar'])
+                self._sgn_pars_[ipdf][f'{self._name_}_sigmal_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_sigmal_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigmal'],
+                    self._limits_sgn_pars_[ipdf]['sigmal'][0], self._limits_sgn_pars_[ipdf]['sigmal'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['sigmal'])
+                self._signal_pdf_[ipdf] = zfit.pdf.BifurGauss(
+                    obs=obs,
+                    mu=self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'],
+                    sigmar=self._sgn_pars_[ipdf][f'{self._name_}_sigmar_signal{ipdf}'],
+                    sigmal=self._sgn_pars_[ipdf][f'{self._name_}_sigmal_signal{ipdf}']
+                )
+            elif pdf_name == 'genercrystalball':
+                self._init_sgn_pars_[ipdf].setdefault('mu', 1.865)
+                self._init_sgn_pars_[ipdf].setdefault('sigmar', 0.010)
+                self._init_sgn_pars_[ipdf].setdefault('sigmal', 0.010)
+                self._init_sgn_pars_[ipdf].setdefault('alphal', 0.5)
+                self._init_sgn_pars_[ipdf].setdefault('nl', 1.)
+                self._init_sgn_pars_[ipdf].setdefault('alphar', 0.5)
+                self._init_sgn_pars_[ipdf].setdefault('nr', 1.)
+                self._fix_sgn_pars_[ipdf].setdefault('mu', False)
+                self._fix_sgn_pars_[ipdf].setdefault('sigmar', False)
+                self._fix_sgn_pars_[ipdf].setdefault('sigmal', False)
+                self._fix_sgn_pars_[ipdf].setdefault('alphal', False)
+                self._fix_sgn_pars_[ipdf].setdefault('nl', False)
+                self._fix_sgn_pars_[ipdf].setdefault('alphar', False)
+                self._fix_sgn_pars_[ipdf].setdefault('nr', False)
+                self._limits_sgn_pars_[ipdf].setdefault('mu', [0, 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('sigmar', [0., 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('sigmal', [0., 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('alphal', [0, 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('nl', [0., 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('alphar', [0, 1.e6])
+                self._limits_sgn_pars_[ipdf].setdefault('nr', [0., 1.e6])
+                self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_mu_signal{ipdf}', self._init_sgn_pars_[ipdf]['mu'],
+                    self._limits_sgn_pars_[ipdf]['mu'][0], self._limits_sgn_pars_[ipdf]['mu'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['mu'])
+                self._sgn_pars_[ipdf][f'{self._name_}_sigmal_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_sigma_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigmal'],
+                    self._limits_sgn_pars_[ipdf]['sigmal'][0], self._limits_sgn_pars_[ipdf]['sigmal'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['sigmal'])
+                self._sgn_pars_[ipdf][f'{self._name_}_sigmar_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_sigmar_signal{ipdf}', self._init_sgn_pars_[ipdf]['sigmar'],
+                    self._limits_sgn_pars_[ipdf]['sigmar'][0], self._limits_sgn_pars_[ipdf]['sigmar'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['sigmar'])
+                self._sgn_pars_[ipdf][f'{self._name_}_alphal_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_alphal_signal{ipdf}', self._init_sgn_pars_[ipdf]['alphal'],
+                    self._limits_sgn_pars_[ipdf]['alphal'][0], self._limits_sgn_pars_[ipdf]['alphal'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['alphal'])
+                self._sgn_pars_[ipdf][f'{self._name_}_nl_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_nl_signal{ipdf}', self._init_sgn_pars_[ipdf]['nl'],
+                    self._limits_sgn_pars_[ipdf]['nl'][0], self._limits_sgn_pars_[ipdf]['nl'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['nl'])
+                self._sgn_pars_[ipdf][f'{self._name_}_alphar_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_alphar_signal{ipdf}', self._init_sgn_pars_[ipdf]['alphar'],
+                    self._limits_sgn_pars_[ipdf]['alphar'][0], self._limits_sgn_pars_[ipdf]['alphar'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['alphar'])
+                self._sgn_pars_[ipdf][f'{self._name_}_nr_signal{ipdf}'] = zfit.Parameter(
+                    f'{self._name_}_nr_signal{ipdf}', self._init_sgn_pars_[ipdf]['nr'],
+                    self._limits_sgn_pars_[ipdf]['nr'][0], self._limits_sgn_pars_[ipdf]['nr'][1],
+                    floating=not self._fix_sgn_pars_[ipdf]['nr'])
+                self._signal_pdf_[ipdf] = zfit.pdf.GeneralizedCB(
+                    obs=obs,
+                    mu=self._sgn_pars_[ipdf][f'{self._name_}_mu_signal{ipdf}'],
+                    sigmar=self._sgn_pars_[ipdf][f'{self._name_}_sigmar_signal{ipdf}'],
+                    sigmal=self._sgn_pars_[ipdf][f'{self._name_}_sigmal_signal{ipdf}'],
+                    alphal=self._sgn_pars_[ipdf][f'{self._name_}_alphal_signal{ipdf}'],
+                    nl=self._sgn_pars_[ipdf][f'{self._name_}_nl_signal{ipdf}'],
+                    alphar=self._sgn_pars_[ipdf][f'{self._name_}_alphar_signal{ipdf}'],
+                    nr=self._sgn_pars_[ipdf][f'{self._name_}_nr_signal{ipdf}']
                 )
             elif 'kde' in pdf_name:
                 if self._kde_signal_sample_[ipdf]:
@@ -1052,7 +1220,8 @@ class F2MassFitter:
                 sigma, sigma_unc = None, None
                 gamma, gamma_unc = None, None
                 rawyield, rawyield_err = self.get_raw_yield(idx=idx)
-                if self._name_signal_pdf_[idx] in ['gaussian', 'crystalball', 'doublecb', 'voigtian', 'hist']:
+                if self._name_signal_pdf_[idx] in [
+                    'gausexptail', 'gaussian', 'crystalball', 'doublecb', 'voigtian', 'hist']:
                     sigma, sigma_unc = self.get_sigma(idx)
                 if self._name_signal_pdf_[idx] in ['cauchy', 'voigtian']:
                     gamma, gamma_unc = self.get_signal_parameter(idx, 'gamma')
@@ -1493,7 +1662,7 @@ class F2MassFitter:
 
         if use_nsigma:
             if self._name_signal_pdf_[idx] not in [
-                'gaussian', 'crystalball', 'doublecb', 'voigtian', 'hist']:
+                'gaussian', 'gausexptail', 'crystalball', 'doublecb', 'voigtian', 'hist']:
                 Logger('Sigma not defined, I cannot compute the signal for this pdf', 'ERROR')
                 return 0., 0.
             mass, _ = self.get_mass(idx)
@@ -1541,7 +1710,7 @@ class F2MassFitter:
             mass = np.average(centres, weights=counts)
             mass_err = 0.
         else:
-            mass_name = 'm' if self._name_signal_pdf_[idx] == 'cauchy' else 'mu'
+            mass_name = 'm' if self._name_signal_pdf_[idx] in ['cauchy', 'voigtian'] else 'mu'
             if self._fix_sgn_pars_[idx][mass_name]:
                 mass = self._init_sgn_pars_[idx][mass_name]
                 mass_err = 0.
@@ -1567,7 +1736,8 @@ class F2MassFitter:
         sigma_err: float
             The sigma error obtained from the fit
         """
-        if self._name_signal_pdf_[idx] not in ['gaussian', 'crystalball', 'doublecb', 'voigtian', 'hist']:
+        if self._name_signal_pdf_[idx] not in [
+            'gaussian', 'gausexptail', 'crystalball', 'doublecb', 'voigtian', 'hist']:
             Logger(f'Sigma parameter not defined for {self._name_signal_pdf_[idx]} pdf!', 'ERROR')
             return 0., 0.
 
@@ -1753,7 +1923,7 @@ class F2MassFitter:
 
         if use_nsigma:
             if self._name_signal_pdf_[idx] not in [
-                'gaussian', 'crystalball', 'doublecb', 'voigtian', 'hist']:
+                'gaussian', 'gausexptail', 'crystalball', 'doublecb', 'voigtian', 'hist']:
                 Logger('Sigma not defined, I cannot compute the signal for this pdf', 'ERROR')
                 return 0., 0.
             mass, _ = self.get_mass(idx)
@@ -1847,7 +2017,7 @@ class F2MassFitter:
 
         if use_nsigma:
             if self._name_signal_pdf_[idx] not in [
-                'gaussian', 'crystalball', 'doublecb', 'voigtian', 'hist']:
+                'gaussian', 'gausexptail', 'crystalball', 'doublecb', 'voigtian', 'hist']:
                 Logger('Sigma not defined, I cannot compute the signal for this pdf', 'ERROR')
                 return 0., 0.
             mass, _ = self.get_mass(idx)

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -387,7 +387,7 @@ class F2MassFitter:
                 self._init_sgn_pars_[ipdf].setdefault('m', 1.865)
                 self._init_sgn_pars_[ipdf].setdefault('gamma', 0.010)
                 self._init_sgn_pars_[ipdf].setdefault('sigma', 0.010)
-                self._fix_sgn_pars_[ipdf].setdefault('mu', False)
+                self._fix_sgn_pars_[ipdf].setdefault('m', False)
                 self._fix_sgn_pars_[ipdf].setdefault('gamma', False)
                 self._fix_sgn_pars_[ipdf].setdefault('sigma', False)
                 self._limits_sgn_pars_[ipdf].setdefault('m', [0, 1.e6])
@@ -2163,7 +2163,7 @@ class F2MassFitter:
             - fix: bool
                 fix the mass parameter
         """
-        mass_name = 'm' if self._name_signal_pdf_[idx] == 'cauchy' else 'mu'
+        mass_name = 'm' if self._name_signal_pdf_[idx] in ['cauchy', 'voigtian'] else 'mu'
         mass = 0.
         if 'mass' in kwargs:
             mass = kwargs['mass']

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ uproot>=5.0
 zfit>=0.20.2
 mplhep>=0.3.46
 matplotlib>=3.8
-particle>=0.20.1
-scipy>=1.7.3
+particle>=0.23
+scipy>=1.13

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ SETUP = Setup(
     name="flarefly",
 
     # LAST-TAG is a placeholder. Automatically replaced at deploy time with the right tag
-    version="0.0.9",
+    version="0.0.10",
     description="FLexible And REliable Fitting LibrarY for particle physics analysis",
     url="https://github.com/flarefly/flarefly",
     author="flarefly-developers",
@@ -89,7 +89,7 @@ SETUP = Setup(
     install_requires=[
         "psutil", "dutil", "prophet>=1.0.1", "numpy<1.25", "pandas>=2.2", "uproot>=5.0",
         "ipython>=7.16.1", "jedi>=0.17.2", "zfit>=0.20.2", "mplhep>=0.3.46", "matplotlib>=3.8",
-        "particle>=0.20.1", "scipy>=1.7.3"
+        "particle>=0.23", "scipy>=1.13"
     ],
     python_requires=">=3.8",
 

--- a/tests/test_massfitter_binned.py
+++ b/tests/test_massfitter_binned.py
@@ -12,11 +12,11 @@ from flarefly.data_handler import DataHandler
 from flarefly.fitter import F2MassFitter
 
 FITTERBINNEDDPLUS, FITTERBINNEDDSTAR, FITTERBINNEDD0, FITRES, FIG, RAWYHIST, RAWYIN = ([] for _ in range(7))
-SGNPDFSDPLUS = ["gaussian", "crystalball", "doublegaus", "doublecb"]
+SGNPDFSDPLUS = ["gaussian", "crystalball", "doublegaus", "doublecb", "genercrystalball"]
 BKGPDFSDPLUS = ["expo", "chebpol1"]
 SGNPDFSDSTAR = ["gaussian", "voigtian"]
 BKGPDFSDSTAR = ["expopow", "powlaw", "expopowext"]
-SGNPDFSD0 = ["gaussian"]
+SGNPDFSD0 = ["gaussian", "gausexptail", "genergausexptail"]
 BKGPDFSD0 = ["expo"]
 
 # test all possible functions with D+
@@ -34,15 +34,17 @@ for bkg_pdf in BKGPDFSDPLUS:
         FITTERBINNEDDPLUS[-1].set_particle_mass(1, pdg_id=413, limits=[2.00, 2.02])
         FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "frac", 0.3, limits=[0.2, 0.4])
         FITTERBINNEDDPLUS[-1].set_signal_initpar(1, "frac", 0.05, limits=[0.01, 0.1])
-        if sgn_pdf in ["gaussian", "crystalball"]:
+        if sgn_pdf in ["gaussian", "crystalball", "doublecb"]:
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "sigma", 0.010)
-        elif sgn_pdf == "doublecb":
-            FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "sigma", 0.010)
+        if sgn_pdf in ["doublecb", "genercrystalball"]:
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "alphal", 2.)
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "nl", 1.)
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "alphar", 2.)
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "nr", 1.)
-        elif sgn_pdf == "doublegaus":
+        if sgn_pdf == "genercrystalball":
+            FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "sigmal", 0.010)
+            FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "sigmar", 0.010)
+        if sgn_pdf == "doublegaus":
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "sigma1", 0.010, limits=[0.008, 0.020])
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "sigma2", 0.100)
             FITTERBINNEDDPLUS[-1].set_signal_initpar(0, "frac1", 0.99, limits=[0.97, 1.00])
@@ -101,9 +103,16 @@ for bkg_pdf in BKGPDFSD0:
                               name_background_pdf=[bkg_pdf],
                               name_refl_pdf=["hist"], name=f"dzero_{bkg_pdf}_{sgn_pdf}", tol=1.e-3))
         FITTERBINNEDD0[-1].set_reflection_template(0, REFLBINNEDD0, 0.294)
-        FITTERBINNEDD0[-1].set_particle_mass(0, pdg_id=421, fix=False)
+        FITTERBINNEDD0[-1].set_particle_mass(0, pdg_id=421, limits=[1.86, 1.90])
         FITTERBINNEDD0[-1].set_signal_initpar(0, "frac", 0.1, limits=[0., 1.])
         FITTERBINNEDD0[-1].set_signal_initpar(0, "sigma", 0.01, limits=[0.005, 0.03])
+        if sgn_pdf == "gausexptail":
+            FITTERBINNEDD0[-1].set_signal_initpar(0, "alpha", 1.e6, limits=[0., 1.e10], fix=True)
+        elif sgn_pdf == "genergausexptail":
+            FITTERBINNEDD0[-1].set_signal_initpar(0, "alphar", 1.e6, fix=True)
+            FITTERBINNEDD0[-1].set_signal_initpar(0, "alphal", 1.e6, fix=True)
+            FITTERBINNEDD0[-1].set_signal_initpar(0, "sigmar", 0.01, limits=[0.005, 0.03])
+            FITTERBINNEDD0[-1].set_signal_initpar(0, "sigmal", 0.01, limits=[0.005, 0.03])
         FITTERBINNEDD0[-1].set_background_initpar(0, "c0", 2.)
         FITTERBINNEDD0[-1].set_background_initpar(0, "c1", -0.293708)
         FITTERBINNEDD0[-1].set_background_initpar(0, "c2", 0.02)


### PR DESCRIPTION
This PR addresses https://github.com/flarefly/flarefly/issues/82 the following functions:
- `gausexptail` (https://zfit.readthedocs.io/en/latest/user_api/pdf/_generated/basic/zfit.pdf.GaussExpTail.html)
- `bifurgaus` (https://zfit.readthedocs.io/en/latest/user_api/pdf/_generated/basic/zfit.pdf.BifurGauss.html)
- `genergausexptail` (https://zfit.readthedocs.io/en/latest/user_api/pdf/_generated/basic/zfit.pdf.GeneralizedGaussExpTail.html)
- `genercrystalball` (https://zfit.readthedocs.io/en/latest/user_api/pdf/_generated/basic/zfit.pdf.GeneralizedCB.html)

And replaces the custom `voigtian` pdf with the one defined in `zfit` (https://zfit.readthedocs.io/en/latest/user_api/pdf/_generated/basic/zfit.pdf.Voigt.html)

I also dumped the version to `0.0.10` for a new release.