### PR TITLE
User-defined labels for pdfs + return tuple in plot_mass_fit

### DIFF
--- a/tests/test_massfitter_binned.py
+++ b/tests/test_massfitter_binned.py
@@ -149,4 +149,5 @@ def test_plot():
     Test the mass fitter plot
     """
     for fig in FIG:
-        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(fig[0], matplotlib.figure.Figure)
+        assert isinstance(fig[1], matplotlib.figure.Axes)

--- a/tests/test_massfitter_unbinned.py
+++ b/tests/test_massfitter_unbinned.py
@@ -55,7 +55,8 @@ def test_plot():
     Test the mass fitter plot
     """
     for fig in FIGS:
-        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(fig[0], matplotlib.figure.Figure)
+        assert isinstance(fig[1], matplotlib.figure.Axes)
 
 def test_dump():
     """


### PR DESCRIPTION
Hi @fgrosa !

With a lot of delay, I send you a small update:
-  we now can define our own labels for signal and bkg (instead of having signal 0, background 0 for instance)
-  `plot_mass_fit` function now also returns `axs`, so one can add some more information on the canvas thanks to `AnchoredText` (as we do in this function)

I tested it and it works :)