### PR TITLE
Add possibility of fitting on disjoint ranges

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.9, 3.10.x, 3.11.x]
+        python-version: [3.9, 3.10.x, 3.11.6]
         test-tool: [pylint, flake8, pytest]
 
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9, 3.10.x, 3.11.x]
+        python-version: [3.9, 3.10.x, 3.11.6]
         test-tool: [pytest]
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.9, 3.10.x, 3.11.6]
+        python-version: [3.9, 3.10.x, 3.11.x]
         test-tool: [pylint, flake8, pytest]
 
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9, 3.10.x, 3.11.6]
+        python-version: [3.9, 3.10.x, 3.11.x]
         test-tool: [pytest]
 
     steps:

--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -1,7 +1,8 @@
 """
 Simple module with a class to manage the data used in the analysis
 """
-
+import os
+os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import numpy as np
 import zfit
 import pandas as pd

--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -3,6 +3,8 @@ Simple module with a class to manage the data used in the analysis
 """
 
 import numpy as np
+import os
+os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1"
 import zfit
 import pandas as pd
 import uproot

--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -2,9 +2,9 @@
 Simple module with a class to manage the data used in the analysis
 """
 
-import numpy as np
 import os
 os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
+import numpy as np
 import zfit
 import pandas as pd
 import uproot

--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -2,8 +2,6 @@
 Simple module with a class to manage the data used in the analysis
 """
 
-import os
-os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import numpy as np
 import zfit
 import pandas as pd

--- a/flarefly/data_handler.py
+++ b/flarefly/data_handler.py
@@ -4,7 +4,7 @@ Simple module with a class to manage the data used in the analysis
 
 import numpy as np
 import os
-os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1"
+os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import zfit
 import pandas as pd
 import uproot

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -1,7 +1,8 @@
 """
 Module containing the class used to perform mass fits
 """
-
+import os
+os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -947,7 +947,10 @@ class F2MassFitter:
                     floating=not self._fix_bkg_pars_[ipdf]['frac'])
 
         self._total_pdf_ = zfit.pdf.SumPDF(self._signal_pdf_+self._refl_pdf_+self._background_pdf_,
-                                           self._fracs_).to_truncated(limits = self._limits_, obs = obs, norm = obs)
+                                           self._fracs_)
+
+        if not self._data_handler_.get_is_binned():
+            self._total_pdf_ = self._total_pdf_.to_truncated(limits = self._limits_, obs = obs, norm = obs)
 
     def __build_total_pdf_binned(self):
         """
@@ -967,10 +970,7 @@ class F2MassFitter:
                 return
             if len(self._background_pdf_) == 0:
                 self._total_pdf_binned_ = zfit.pdf.BinnedFromUnbinnedPDF(self._signal_pdf_[0], obs)
-                return
-
-        self._total_pdf_binned_ = zfit.pdf.BinnedFromUnbinnedPDF(zfit.pdf.SumPDF(
-                            self._signal_pdf_+self._refl_pdf_+self._background_pdf_, self._fracs_), obs)
+        self._total_pdf_binned_ = zfit.pdf.BinnedFromUnbinnedPDF(self._total_pdf_, obs)
 
     def __prefit(self):
         """

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -2,8 +2,6 @@
 Module containing the class used to perform mass fits
 """
 
-import os
-os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
@@ -1274,8 +1272,7 @@ class F2MassFitter:
         for signal_pdf in self._signal_pdf_:
             signal_funcs.append(zfit.run(signal_pdf.pdf(x_plot, norm_range=obs)))
         for refl_pdf in self._refl_pdf_:
-            refl_pdf_pdf = refl_pdf.pdf(x_plot, norm_range=obs)
-            refl_funcs.append(zfit.run(refl_pdf_pdf))
+            refl_funcs.append(zfit.run(refl_pdf.pdf(x_plot, norm_range=obs)))
         for bkg_pdf in self._background_pdf_:
             bkg_funcs.append(zfit.run(bkg_pdf.pdf(x_plot, norm_range=obs)))
 

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -7,6 +7,8 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 from matplotlib.offsetbox import AnchoredText
 
+import os
+os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1"
 import zfit
 import uproot
 from hist import Hist

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -2,13 +2,13 @@
 Module containing the class used to perform mass fits
 """
 
+import os
+os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 from matplotlib.offsetbox import AnchoredText
 
-import os
-os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import zfit
 import uproot
 from hist import Hist
@@ -1274,7 +1274,8 @@ class F2MassFitter:
         for signal_pdf in self._signal_pdf_:
             signal_funcs.append(zfit.run(signal_pdf.pdf(x_plot, norm_range=obs)))
         for refl_pdf in self._refl_pdf_:
-            refl_funcs.append(zfit.run(refl_pdf.pdf(x_plot, norm_range=obs)))
+            refl_pdf_pdf = refl_pdf.pdf(x_plot, norm_range=obs)
+            refl_funcs.append(zfit.run(refl_pdf_pdf))
         for bkg_pdf in self._background_pdf_:
             bkg_funcs.append(zfit.run(bkg_pdf.pdf(x_plot, norm_range=obs)))
 

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -8,7 +8,7 @@ from matplotlib.colors import ListedColormap
 from matplotlib.offsetbox import AnchoredText
 
 import os
-os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1"
+os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import zfit
 import uproot
 from hist import Hist


### PR DESCRIPTION
With this PR it is possible to define fitting ranges (also on disjoint spaces) using the `limits` keyword. 
For the moment, it is only possible to do so for unbinned fits (as for binned fits we are facing some [issues](https://github.com/zfit/zfit/issues/579)).

This implementation relies on [`TruncatedPDF`](https://zfit.readthedocs.io/en/stable/user_api/pdf/_generated/composed_pdf/zfit.pdf.TruncatedPDF.html#truncatedpdf)s to fit on multiple ranges. A `TruncatedPDF` is now used as default `_total_pdf_` in place of non-truncated `PDF`s, also in case that no restriction of the fit limits is provided.