### PR TITLE
Fix chi2 and standard residuals evaluation with unbinned data

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,4 +15,5 @@ disable=useless-object-inheritance
 
 [DESIGN]
 max-args=10
+max-positional-arguments=8
 max-locals=100

--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -970,7 +970,10 @@ class F2MassFitter:
                 return
             if len(self._background_pdf_) == 0:
                 self._total_pdf_binned_ = zfit.pdf.BinnedFromUnbinnedPDF(self._signal_pdf_[0], obs)
-        self._total_pdf_binned_ = zfit.pdf.BinnedFromUnbinnedPDF(self._total_pdf_, obs)
+                return
+
+        self._total_pdf_binned_ = zfit.pdf.BinnedFromUnbinnedPDF(zfit.pdf.SumPDF(
+            self._signal_pdf_+self._refl_pdf_+self._background_pdf_, self._fracs_), obs)
 
     def __prefit(self):
         """
@@ -1112,6 +1115,8 @@ class F2MassFitter:
             data_values = binned_data.values()
             variances = binned_data.variances()
         else:
+            if self._limits_ != [self._data_handler_.get_limits()]: # restricted fit limits
+                Logger('Standard residuals not yet implemented with restricted fit limits', 'FATAL')
             data_values = self._data_handler_.get_binned_data_from_unbinned_data()
             variances = data_values # poissonian errors
 
@@ -1511,6 +1516,8 @@ class F2MassFitter:
                 chi2 += (data - model)**2/data_variance
             return chi2
 
+        if self._limits_ != [self._data_handler_.get_limits()]: # restricted fit limits
+            Logger('chi2 not yet implemented with restricted fit limits', 'FATAL')
         # for unbinned data
         data_values = self._data_handler_.get_binned_data_from_unbinned_data()
         # access model predicted values


### PR DESCRIPTION
This PR prevents the fitter from crashing when retrieving the chi2 and standard residuals during an unbinned fit with a non-truncated `PDF`

Before this fix, the code would fail because it attempted to use a binned `TruncatedPDF`, which is currently affected by an issue, which makes it crash. The fix ensures that `self._total_pdf_binned_` is now built as a non-truncated `PDF` even for unbinned fits, and safeguards have been added to prevent chi2 and standard residuals retrieval when limiting the fitting range.