### PR TITLE
Add function to return sweights

### DIFF
--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -12,6 +12,7 @@ import zfit
 import uproot
 from hist import Hist
 import mplhep
+from hepstats.splot import compute_sweights
 from particle import Particle
 from flarefly.utils import Logger
 import flarefly.custom_pdfs as cpdf
@@ -2256,6 +2257,60 @@ class F2MassFitter:
                 bkg[0]/sig_plus_bkg) * signal[1]**2 / signal[0]**2)
 
         return significance, significance_err
+
+    def get_sweights(self):
+        """
+        Calculate sWeights for signal and background components.
+
+        Returns:
+            dict: A dictionary containing sWeights for 'signal' and 'bkg' components.
+        """
+
+        signal_pdf_extended = []
+        refl_pdf_extended = []
+        bkg_pdf_extended = []
+
+        norm = self._data_handler_.get_norm()
+
+        signal_fracs, bkg_fracs, refl_fracs, _, _, _ = self.__get_all_fracs()
+        bkg_fracs.append(1-sum(bkg_fracs)-sum(signal_fracs)-sum(refl_fracs))
+
+        total_signal_yields = 0.
+        total_bkg_yields = 0.
+        for pdf, frac in zip(self._signal_pdf_, signal_fracs):
+            signal_pdf_extended.append(pdf.create_extended(frac * norm))
+            total_signal_yields += frac * norm
+        for pdf, frac in zip(self._refl_pdf_, refl_fracs):
+            refl_pdf_extended.append(pdf.create_extended(frac * norm))
+            total_signal_yields += frac * norm
+        for pdf, frac in zip(self._background_pdf_, bkg_fracs):
+            bkg_pdf_extended.append(pdf.create_extended(frac * norm))
+            total_bkg_yields += frac * norm
+
+        total_signal_yields_par = zfit.Parameter('signal_yield', total_signal_yields)
+        total_bkg_yields_par = zfit.Parameter('bkg_yield', total_bkg_yields)
+
+        if len(signal_pdf_extended + refl_pdf_extended) > 1:
+            signal_pdf_for_sweights = zfit.pdf.SumPDF(
+                signal_pdf_extended + refl_pdf_extended,
+                extended=total_signal_yields_par
+            )
+        else:
+            signal_pdf_for_sweights = signal_pdf_extended[0]
+
+        if len(bkg_pdf_extended) > 1:
+            bkg_pdf_for_sweights = zfit.pdf.SumPDF(
+                bkg_pdf_extended,
+                extended=total_bkg_yields_par
+            )
+        else:
+            bkg_pdf_for_sweights = bkg_pdf_extended[0]
+
+        total_pdf_for_sweights = zfit.pdf.SumPDF([signal_pdf_for_sweights, bkg_pdf_for_sweights])
+        sweights = compute_sweights(total_pdf_for_sweights, self._data_handler_.get_data())
+        sweights_labels = list(sweights.keys())
+
+        return {'signal': sweights[sweights_labels[0]], 'bkg': sweights[sweights_labels[1]]}
 
     def set_particle_mass(self, idx, **kwargs):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ dutil
 numpy<1.25
 pandas>=2.2.0
 uproot>=5.0
-zfit>=0.20.2
+zfit>=0.22.0
 mplhep>=0.3.46
 matplotlib>=3.9
 particle>=0.23
 scipy>=1.13
+hepstats>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ SETUP = Setup(
     install_requires=[
         "psutil", "dutil", "prophet>=1.0.1", "numpy<1.25", "pandas>=2.2", "uproot>=5.0",
         "ipython>=7.16.1", "jedi>=0.17.2", "zfit>=0.20.2", "mplhep>=0.3.46", "matplotlib>=3.9",
-        "particle>=0.23", "scipy>=1.13"
+        "particle>=0.23", "scipy>=1.13", "hepstats>=0.8.1"
     ],
     python_requires=">=3.8",
 


### PR DESCRIPTION
This PR adds a function that returns the sweights.
For now, only 2 classes are considered: signal and background.

The package requirements changed: `hepstats` package was added, and the `zfit` version was updated to the latest one