### PR TITLE
__get_all_fracs now returns all the fractions and fix normalisation for fits with truncated PDFs

### DIFF
--- a/flarefly/fitter.py
+++ b/flarefly/fitter.py
@@ -2384,7 +2384,7 @@ class F2MassFitter:
             norm = self._total_pdf_norm_ * bkg_fracs[idx2]
             norm_err = norm * bkg_err_fracs[idx2]
 
-            bkg_int = bkg.integrate((min_value, max_value))
+            bkg_int = float(bkg.integrate((min_value, max_value)))
             background += bkg_int * norm
             background_err += (bkg_int * norm_err)**2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 psutil
 dutil
-numpy<1.25
+numpy<2.0.0
 pandas>=2.2.0
 uproot>=5.0
 zfit>=0.22.0

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ SETUP = Setup(
     # installed. For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "psutil", "dutil", "prophet>=1.0.1", "numpy<1.25", "pandas>=2.2", "uproot>=5.0",
+        "psutil", "dutil", "prophet>=1.0.1", "numpy<2.0.0", "pandas>=2.2", "uproot>=5.0",
         "ipython>=7.16.1", "jedi>=0.17.2", "zfit>=0.20.2", "mplhep>=0.3.46", "matplotlib>=3.9",
         "particle>=0.23", "scipy>=1.13", "hepstats>=0.8.1"
     ],

--- a/tests/test_massfitter_unbinned.py
+++ b/tests/test_massfitter_unbinned.py
@@ -12,6 +12,7 @@ from flarefly.data_handler import DataHandler
 from flarefly.fitter import F2MassFitter
 
 LIMITS = [1.75, 2.1]
+np.random.seed(42)
 DATASGN = np.random.normal(1.865, 0.010, size=10000)
 DATASGN2 = np.random.normal(1.968, 0.010, size=20000)
 DATABKG = np.random.exponential(scale=0.1, size=30000) + LIMITS[0]
@@ -42,7 +43,7 @@ FITTER.append(F2MassFitter(DATANOBKG2,
                            name_signal_pdf=['gaussian', 'gaussian'],
                            name_background_pdf=['nobkg'],
                            minuit_mode=1,
-                           name="nobkg"))
+                           name="nobkg_2signals"))
 FITRES.append(FITTER[2].mass_zfit())
 FIGS.append(FITTER[2].plot_mass_fit(figsize=(10, 10)))
 
@@ -51,25 +52,27 @@ DATA2 = DataHandler(np.concatenate((DATASGN, DATASGN2, DATABKG), axis=0),
                     var_name=r'$M$ (GeV/$c^{2}$)', limits=LIMITS)
 FITTER.append(F2MassFitter(DATA2, name_signal_pdf=['gaussian', 'gaussian'],
                            name_background_pdf=['expo'],
-                           minuit_mode=1))
+                           minuit_mode=1,
+                           name="fix_frac"))
 FITTER[3].set_background_initpar(0, 'lam', -10, limits=[-15., -5.], fix=False)
 FITTER[3].set_particle_mass(0, mass=1.85, limits=[1.84, 1.88])
 FITTER[3].set_particle_mass(1, mass=1.95, limits=[1.94, 1.98])
 FITTER[3].set_signal_initpar(0, 'sigma', 0.01, limits=[0.005, 0.03])
 FITTER[3].set_signal_initpar(1, 'sigma', 0.01, limits=[0.005, 0.03])
 FITTER[3].fix_signal_frac_to_signal_pdf(1, 0, 2)
-FITRES.append(FITTER[3].mass_zfit(True, prefit_exclude_nsigma=3.))
+FITRES.append(FITTER[3].mass_zfit(True, prefit_exclude_nsigma=5.))
 FIGS.append(FITTER[3].plot_mass_fit(figsize=(10, 10)))
 
 # test truncated pdfs
 FITTER.append(F2MassFitter(DATA2, name_signal_pdf=['gaussian'],
                            name_background_pdf=['expo'],
                            limits=[[1.75, 1.92], [2.02, 2.1]],
-                           minuit_mode=1))
+                           minuit_mode=1,
+                           name="truncated"))
 FITTER[4].set_background_initpar(0, 'lam', -10, limits=[-15., -5.], fix=False)
 FITTER[4].set_particle_mass(0, mass=1.85, limits=[1.84, 1.88])
 FITTER[4].set_signal_initpar(0, 'sigma', 0.01, limits=[0.005, 0.03])
-FITRES.append(FITTER[4].mass_zfit(True, prefit_exclude_nsigma=3.))
+FITRES.append(FITTER[4].mass_zfit())
 FIGS.append(FITTER[4].plot_mass_fit(figsize=(10, 10)))
 
 def test_fitter():

--- a/tests/test_massfitter_unbinned.py
+++ b/tests/test_massfitter_unbinned.py
@@ -5,6 +5,7 @@ Test for unbinned fit with flarefly.F2MassFitter
 import os
 os.environ["ZFIT_DISABLE_TF_WARNINGS"] = "1" # pylint: disable=wrong-import-position
 import zfit
+import uproot
 import numpy as np
 import matplotlib
 from flarefly.data_handler import DataHandler
@@ -13,7 +14,7 @@ from flarefly.fitter import F2MassFitter
 LIMITS = [1.75, 2.1]
 DATASGN = np.random.normal(1.865, 0.010, size=10000)
 DATASGN2 = np.random.normal(1.968, 0.010, size=20000)
-DATABKG = np.random.uniform(LIMITS[0], LIMITS[1], size=10000)
+DATABKG = np.random.exponential(scale=0.1, size=30000) + LIMITS[0]
 DATA = DataHandler(np.concatenate((DATASGN, DATABKG), axis=0),
                    var_name=r'$M$ (GeV/$c^{2}$)', limits=LIMITS)
 
@@ -21,10 +22,10 @@ FITRES, FITTER, FIGS = [], [], []
 FITTER.append(F2MassFitter(DATA, name_signal_pdf=['gaussian'],
                            name_background_pdf=['expo'],
                            minuit_mode=1))
-FITTER[0].set_background_initpar(0, 'lam', 0.1, limits=[-10., 10.], fix=False)
+FITTER[0].set_background_initpar(0, 'lam', -10, limits=[-15., -5.], fix=False)
 FITRES.append(FITTER[0].mass_zfit(True, prefit_excluded_regions=[1.8, 1.95]))
 FIGS.append(FITTER[0].plot_mass_fit(figsize=(10, 10)))
-FITTER[0].dump_to_root("test.root")
+FITTER[0].dump_to_root("test.root", num=100)
 
 # test also nobkg case
 DATANOBKG = DataHandler(DATASGN, var_name=r'$M$ (GeV/$c^{2}$)', limits=LIMITS)
@@ -35,19 +36,41 @@ FITTER.append(F2MassFitter(DATANOBKG, name_signal_pdf=['gaussian'],
 FITRES.append(FITTER[1].mass_zfit())
 FIGS.append(FITTER[1].plot_mass_fit(figsize=(10, 10)))
 
+DATANOBKG2 = DataHandler(np.concatenate((DATASGN, DATASGN2), axis=0),
+                         var_name=r'$M$ (GeV/$c^{2}$)', limits=LIMITS)
+FITTER.append(F2MassFitter(DATANOBKG2,
+                           name_signal_pdf=['gaussian', 'gaussian'],
+                           name_background_pdf=['nobkg'],
+                           minuit_mode=1,
+                           name="nobkg"))
+FITRES.append(FITTER[2].mass_zfit())
+FIGS.append(FITTER[2].plot_mass_fit(figsize=(10, 10)))
+
 # test fixing the relative pdf fractions
 DATA2 = DataHandler(np.concatenate((DATASGN, DATASGN2, DATABKG), axis=0),
                     var_name=r'$M$ (GeV/$c^{2}$)', limits=LIMITS)
 FITTER.append(F2MassFitter(DATA2, name_signal_pdf=['gaussian', 'gaussian'],
-                           name_background_pdf=['chebpol1'],
+                           name_background_pdf=['expo'],
                            minuit_mode=1))
-FITTER[2].set_particle_mass(0, mass=1.85, limits=[1.84, 1.88])
-FITTER[2].set_particle_mass(1, mass=1.95, limits=[1.94, 1.98])
-FITTER[2].set_signal_initpar(0, 'sigma', 0.01, limits=[0.005, 0.03])
-FITTER[2].set_signal_initpar(1, 'sigma', 0.01, limits=[0.005, 0.03])
-FITTER[2].fix_signal_frac_to_signal_pdf(1, 0, 2)
-FITRES.append(FITTER[2].mass_zfit(True, prefit_exclude_nsigma=3.))
-FIGS.append(FITTER[2].plot_mass_fit(figsize=(10, 10)))
+FITTER[3].set_background_initpar(0, 'lam', -10, limits=[-15., -5.], fix=False)
+FITTER[3].set_particle_mass(0, mass=1.85, limits=[1.84, 1.88])
+FITTER[3].set_particle_mass(1, mass=1.95, limits=[1.94, 1.98])
+FITTER[3].set_signal_initpar(0, 'sigma', 0.01, limits=[0.005, 0.03])
+FITTER[3].set_signal_initpar(1, 'sigma', 0.01, limits=[0.005, 0.03])
+FITTER[3].fix_signal_frac_to_signal_pdf(1, 0, 2)
+FITRES.append(FITTER[3].mass_zfit(True, prefit_exclude_nsigma=3.))
+FIGS.append(FITTER[3].plot_mass_fit(figsize=(10, 10)))
+
+# test truncated pdfs
+FITTER.append(F2MassFitter(DATA2, name_signal_pdf=['gaussian'],
+                           name_background_pdf=['expo'],
+                           limits=[[1.75, 1.92], [2.02, 2.1]],
+                           minuit_mode=1))
+FITTER[4].set_background_initpar(0, 'lam', -10, limits=[-15., -5.], fix=False)
+FITTER[4].set_particle_mass(0, mass=1.85, limits=[1.84, 1.88])
+FITTER[4].set_signal_initpar(0, 'sigma', 0.01, limits=[0.005, 0.03])
+FITRES.append(FITTER[4].mass_zfit(True, prefit_exclude_nsigma=3.))
+FIGS.append(FITTER[4].plot_mass_fit(figsize=(10, 10)))
 
 def test_fitter():
     """
@@ -65,11 +88,18 @@ def test_fitter_result():
         rawy_bc, rawy_bc_err = fit.get_raw_yield_bincounting()
         assert np.isclose(10000, rawy, atol=3*rawy_err)
         assert np.isclose(10000, rawy_bc, atol=3*rawy_bc_err)
-        if i_fit == 2:
+        if i_fit in (2, 3):  # test the case with two signals
             rawy2, rawy2_err = fit.get_raw_yield(1)
             rawy2_bc, rawy2_bc_err = fit.get_raw_yield_bincounting(1)
             assert np.isclose(20000, rawy2, atol=3*rawy2_err)
             assert np.isclose(20000, rawy2_bc, atol=3*rawy2_bc_err)
+        if i_fit not in (1, 2): # test the cases with background
+            bkg_fit, bkg_fit_err = fit.get_background(min=1.8, max=1.95)
+            true_bkg = np.count_nonzero(DATABKG[(DATABKG > 1.8) & (DATABKG < 1.95)])
+            assert np.isclose(true_bkg, bkg_fit, atol=5*bkg_fit_err)
+        if i_fit != 4:
+            chi2_ndf = fit.get_chi2_ndf()
+            assert chi2_ndf < 2
 
 def test_plot():
     """
@@ -85,4 +115,11 @@ def test_dump():
     """
 
     assert os.path.isfile("test.root")
+    with uproot.open("test.root", encoding='utf-8') as f:
+        h_signal = f["signal_0"]
+        h_bkg = f["bkg_0"]
+        signal = sum(h_signal.values())
+        bkg = sum(h_bkg.values())
+        assert np.isclose(10000, signal, atol=2000)
+        assert np.isclose(30000, bkg, atol=2000)
     os.remove("test.root")


### PR DESCRIPTION
- `__get_all_fracs` also returns the fraction of the last PDF (i.e., the fraction which is not passed to the SumPDF constructor)
- fix normalisation for fits with `TruncatedPDF`s
- dump numpy version (`<2.0.0`)
- add new tests for unbinned fits