### PR TITLE
Replace `particle` package with `pdg`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ uproot>=5.0
 zfit>=0.22.0
 mplhep>=0.3.46
 matplotlib>=3.9
-particle>=0.23
+pdg>=0.1.3
 scipy>=1.13
 hepstats>=0.8.1

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ SETUP = Setup(
     install_requires=[
         "psutil", "dutil", "prophet>=1.0.1", "numpy<2.0.0", "pandas>=2.2", "uproot>=5.0",
         "ipython>=7.16.1", "jedi>=0.17.2", "zfit>=0.20.2", "mplhep>=0.3.46", "matplotlib>=3.9",
-        "particle>=0.23", "scipy>=1.13", "hepstats>=0.8.1"
+        "pdg>=0.1.3", "scipy>=1.13", "hepstats>=0.8.1"
     ],
     python_requires=">=3.9",
 

--- a/tests/test_massfitter_binned.py
+++ b/tests/test_massfitter_binned.py
@@ -8,9 +8,11 @@ import zfit
 import uproot
 import numpy as np
 import matplotlib
-from particle import Particle
+import pdg
 from flarefly.data_handler import DataHandler
 from flarefly.fitter import F2MassFitter
+
+pdg_api = pdg.connect()
 
 FITTERBINNEDDPLUS, FITTERBINNEDDSTAR, FITTERBINNEDD0, FITRES, FIG, RAWYHIST, RAWYIN = ([] for _ in range(7))
 SGNPDFSDPLUS = ["gaussian", "crystalball", "doublegaus", "doublecb", "genercrystalball"]
@@ -68,7 +70,7 @@ for bkg_pdf in BKGPDFSDPLUS:
 # test also bkg functions for D*
 INFILEDSTAR = os.path.join(os.getcwd(), "tests/histos_dstar.root")
 DATABINNEDDSTAR = DataHandler(INFILEDSTAR, var_name=r"$M_\mathrm{K\pi\pi}-M_\mathrm{K\pi}$ (GeV/$c^{2}$)",
-                              histoname="hMass_40_60", limits=[Particle.from_pdgid(211).mass*1e-3, 0.155], rebin=4,
+                              histoname="hMass_40_60", limits=[pdg_api.get_particle_by_mcid(211).mass, 0.155], rebin=4,
                               tol=1.e-3)
 for bkg_pdf in BKGPDFSDSTAR:
     for sgn_pdf in SGNPDFSDSTAR:


### PR DESCRIPTION
This PR replaces the usage of the `particle` package with that of the [`pdg`](https://pdgapi.lbl.gov/doc/pythonapi.html) package